### PR TITLE
Normal smoothing regularization like unisurf

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -168,6 +168,10 @@ def arguments():
     "--smooth-normals", help="Amount to attempt to smooth normals", type=float, default=0,
   )
   sdfa.add_argument(
+    "--smooth-eps", help="size of random uniform perturbation for smooth normals regularization", 
+    type=float, default=0,
+  )
+  sdfa.add_argument(
     "--sdf-kind", help="Which SDF model to use", type=str,
     choices=["spheres", "siren", "local", "mlp", "triangles"], default="mlp",
   )
@@ -431,11 +435,17 @@ def train(model, cam, labels, opt, args, light=None, sched=None):
     # dn/dx -> 0, hopefully smoothes out the local normals of the surface.
     # TODO does it matter to normalize the normal or not?
     if args.smooth_normals > 0:
-      # TODO maybe lower dimensionality of n?
-      delta_n = torch.autograd.grad(
-        inputs=pts, outputs=F.normalize(n,dim=-1), create_graph=True,
-        grad_outputs=torch.ones_like(n),
-      )[0]
+      if args.smooth_eps > 0:
+        # epsilon-perturbation implementation from unisurf
+        perturbation = F.normalize(torch.rand(3, device=device), dim=-1) * args.smooth_eps
+        perturbation = perturbation.expand(pts.size())
+        delta_n = n - model.sdf.normals(pts + perturbation)
+      else:
+        # TODO maybe lower dimensionality of n?
+        delta_n = torch.autograd.grad(
+          inputs=pts, outputs=F.normalize(n,dim=-1), create_graph=True,
+          grad_outputs=torch.ones_like(n),
+        )[0]
       # TODO maybe convert this to abs? seems to work for nerfactor, altho unisurf uses square?
       loss = loss + args.smooth_normals * torch.linalg.norm(delta_n, dim=-1).square().mean()
 

--- a/runner.py
+++ b/runner.py
@@ -437,8 +437,8 @@ def train(model, cam, labels, opt, args, light=None, sched=None):
     if args.smooth_normals > 0:
       if args.smooth_eps > 0:
         # epsilon-perturbation implementation from unisurf
-        perturbation = F.normalize(torch.rand(3, device=device), dim=-1) * args.smooth_eps
-        perturbation = perturbation.expand(pts.size())
+        perturbation = F.normalize(2*torch.rand(3, device=device)-1, dim=-1) * args.smooth_eps
+        perturbation = perturbation.expand(pts.shape)
         delta_n = n - model.sdf.normals(pts + perturbation)
       else:
         # TODO maybe lower dimensionality of n?


### PR DESCRIPTION
Unisurf features random uniform 3D perturbation for calculating smooth normals loss

--smooth-eps argument determines magnitude of the perturbation; if 0, this regularization is not used